### PR TITLE
Revert "build(deps): bump dompurify from 3.4.0 to 3.4.11"

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@codemirror/view": "^6.38.1",
     "@lezer/highlight": "^1.2.3",
     "codemirror": "^6.0.2",
-    "dompurify": "^3.4.11",
+    "dompurify": "^3.4.0",
     "html2pdf.js": "^0.14.0",
     "marked": "^17.0.1",
     "react": "^19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
       dompurify:
-        specifier: ^3.4.11
-        version: 3.4.11
+        specifier: ^3.4.0
+        version: 3.4.0
       html2pdf.js:
         specifier: ^0.14.0
         version: 0.14.0
@@ -940,8 +940,8 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  dompurify@3.4.11:
-    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+  dompurify@3.4.0:
+    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
@@ -2334,7 +2334,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  dompurify@3.4.11:
+  dompurify@3.4.0:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -2527,7 +2527,7 @@ snapshots:
 
   html2pdf.js@0.14.0:
     dependencies:
-      dompurify: 3.4.11
+      dompurify: 3.4.0
       html2canvas: 1.4.1
       jspdf: 4.2.1
 
@@ -2578,7 +2578,7 @@ snapshots:
     optionalDependencies:
       canvg: 3.0.11
       core-js: 3.47.0
-      dompurify: 3.4.11
+      dompurify: 3.4.0
       html2canvas: 1.4.1
 
   keyv@4.5.4:


### PR DESCRIPTION
This reverts commit a11a4957ae264d6e73d2a8e322646ea260e12380.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependency versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->